### PR TITLE
Ai tweaks + misc

### DIFF
--- a/CvGameCoreDLL/CvPlayerAI.cpp
+++ b/CvGameCoreDLL/CvPlayerAI.cpp
@@ -18494,13 +18494,13 @@ int CvPlayerAI::AI_getEnemyPlotStrength(CvPlot* pPlot, int iRange, bool bDefensi
 int CvPlayerAI::AI_goldToHurryAllUnits() const
 {
 	bool bHurryGold = false;
-	HurryTypes iHurryType;
+	HurryTypes eHurryType;
 	for (int iHurry = 0; iHurry < GC.getNumHurryInfos(); iHurry++)
 	{
 		if ((GC.getHurryInfo((HurryTypes)iHurry).getGoldPerProduction() > 0) && canHurry((HurryTypes)iHurry))
 		{
 			bHurryGold = true;
-			iHurryType = (HurryTypes)iHurry;
+			eHurryType = (HurryTypes)iHurry;
 			break;
 		}
 	}
@@ -18510,9 +18510,9 @@ int CvPlayerAI::AI_goldToHurryAllUnits() const
 	CvCity* pLoopCity;
 	for (pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop)) 
 	{
-		if (pLoopCity->getProductionUnit() != NO_UNIT && pLoopCity->canHurry(iHurryType))
+		if (pLoopCity->getProductionUnit() != NO_UNIT && pLoopCity->canHurry(eHurryType))
 		{
-			iTotalGold += pLoopCity->hurryGold(iHurryType);
+			iTotalGold += pLoopCity->hurryGold(eHurryType);
 		}
 	}
 	return iTotalGold;

--- a/CvGameCoreDLL/CvPlayerAI.cpp
+++ b/CvGameCoreDLL/CvPlayerAI.cpp
@@ -4060,6 +4060,12 @@ int CvPlayerAI::AI_goldTarget() const
 		{
 			iGold *= 10;
 		}
+		
+		// if we are getting close to capitulating or if the enemy out numbers us 2:1 we need money to buy units
+		if (bAnyWar && ( GET_TEAM(getTeam()).AI_getWarSuccessCapitulationRatio() < -51 || GET_TEAM(getTeam()).AI_getEnemyPowerPercent() > 199) )
+		{
+			iGold += AI_goldToHurryAllUnits() / 10;
+		}
 
 		iGold += (AI_goldToUpgradeAllUnits() / (bAnyWar ? 1 : 2));
 
@@ -18483,6 +18489,33 @@ int CvPlayerAI::AI_getEnemyPlotStrength(CvPlot* pPlot, int iRange, bool bDefensi
 
 	return iValue;
 	
+}
+
+int CvPlayerAI::AI_goldToHurryAllUnits() const
+{
+	bool bHurryGold = false;
+	HurryTypes iHurryType;
+	for (int iHurry = 0; iHurry < GC.getNumHurryInfos(); iHurry++)
+	{
+		if ((GC.getHurryInfo((HurryTypes)iHurry).getGoldPerProduction() > 0) && canHurry((HurryTypes)iHurry))
+		{
+			bHurryGold = true;
+			iHurryType = (HurryTypes)iHurry;
+			break;
+		}
+	}
+	if (!bHurryGold) { return 0; }
+	int iTotalGold = 0;
+	int iLoop;
+	CvCity* pLoopCity;
+	for (pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop)) 
+	{
+		if (pLoopCity->getProductionUnit() != NO_UNIT && pLoopCity->canHurry(iHurryType))
+		{
+			iTotalGold += pLoopCity->hurryGold(iHurryType);
+		}
+	}
+	return iTotalGold;
 }
 
 int CvPlayerAI::AI_goldToUpgradeAllUnits(int iExpThreshold) const

--- a/CvGameCoreDLL/CvPlayerAI.cpp
+++ b/CvGameCoreDLL/CvPlayerAI.cpp
@@ -13252,18 +13252,18 @@ void CvPlayerAI::AI_doCommerce()
 			{
 				if (AI_avoidScience())
 				{
-					changeCommercePercent(COMMERCE_RESEARCH, -(GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS")));
+					changeCommercePercent(COMMERCE_RESEARCH, -(GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2")));
 				}
 			}
 
 			if ((GET_TEAM(getTeam()).getChosenWarCount(true) > 0) || (GET_TEAM(getTeam()).getWarPlanCount(WARPLAN_ATTACKED_RECENT, true) > 0))
 			{
-				changeCommercePercent(COMMERCE_RESEARCH, -(GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS")));
+				changeCommercePercent(COMMERCE_RESEARCH, -(GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2")));
 			}
 
 			if ((getCommercePercent(COMMERCE_RESEARCH) == 0) && (calculateGoldRate() > 0))
 			{
-				setCommercePercent(COMMERCE_RESEARCH, GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS"));
+				setCommercePercent(COMMERCE_RESEARCH, GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
 			}
 		}
 	}
@@ -13494,11 +13494,11 @@ void CvPlayerAI::AI_doCommerce()
 		{
 			if (getCommercePercent(COMMERCE_ESPIONAGE) > 0)
 			{
-				changeCommercePercent(COMMERCE_ESPIONAGE, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS"));			
+				changeCommercePercent(COMMERCE_ESPIONAGE, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
 			}
 			else
 			{
-				changeCommercePercent(COMMERCE_RESEARCH, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS"));			
+				changeCommercePercent(COMMERCE_RESEARCH, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
 			}
 			//changeCommercePercent(COMMERCE_GOLD, GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS"));
 		}

--- a/CvGameCoreDLL/CvPlayerAI.cpp
+++ b/CvGameCoreDLL/CvPlayerAI.cpp
@@ -13479,7 +13479,7 @@ void CvPlayerAI::AI_doCommerce()
 		}
 	}
 	
-	if (!bFirstTech && (getGold() < iGoldTarget) && (getCommercePercent(COMMERCE_RESEARCH) > 40))
+	if ((getGold() < iGoldTarget) && (getCommercePercent(COMMERCE_ESPIONAGE) >= 10))
 	{
 		bool bHurryGold = false;
 		for (int iHurry = 0; iHurry < GC.getNumHurryInfos(); iHurry++)
@@ -13492,14 +13492,8 @@ void CvPlayerAI::AI_doCommerce()
 		}
 		if (bHurryGold)
 		{
-			if (getCommercePercent(COMMERCE_ESPIONAGE) > 0)
-			{
-				changeCommercePercent(COMMERCE_ESPIONAGE, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
-			}
-			else
-			{
-				changeCommercePercent(COMMERCE_RESEARCH, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
-			}
+			changeCommercePercent(COMMERCE_ESPIONAGE, -GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2"));
+			changeCommercePercent(COMMERCE_RESEARCH, GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS2")/2);
 			//changeCommercePercent(COMMERCE_GOLD, GC.getDefineINT("COMMERCE_PERCENT_CHANGE_INCREMENTS"));
 		}
 	}

--- a/CvGameCoreDLL/CvPlayerAI.cpp
+++ b/CvGameCoreDLL/CvPlayerAI.cpp
@@ -4052,8 +4052,8 @@ int CvPlayerAI::AI_goldTarget() const
 		bool bAnyWar = GET_TEAM(getTeam()).getAnyWarPlanCount(true) > 0;
 		if (bAnyWar)
 		{
-			iGold *= 3;
-			iGold /= 2;
+			iGold *= 2;
+			// iGold /= 2;
 		}
 
 		if (AI_avoidScience())

--- a/CvGameCoreDLL/CvPlayerAI.h
+++ b/CvGameCoreDLL/CvPlayerAI.h
@@ -339,6 +339,7 @@ public:
     int AI_getEnemyPlotStrength(CvPlot* pPlot, int iRange, bool bDefensiveBonuses, bool bTestMoves) const;
 
 	int AI_goldToUpgradeAllUnits(int iExpThreshold = 0) const;
+	int AI_goldToHurryAllUnits() const;
 
 	int AI_goldTradeValuePercent() const;
 	

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -2730,7 +2730,7 @@ void CvUnitAI::AI_attackCityMove()
 				{
 					iCityCaptureCount++;
 
-					if( iCityCaptureCount > 5 || 3*iCityCaptureCount > getGroup()->getNumUnits() )
+					if( iCityCaptureCount > 2 || 3*iCityCaptureCount > getGroup()->getNumUnits() )
 					{
 						bReadyToAttack = true;
 					}

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -2730,7 +2730,7 @@ void CvUnitAI::AI_attackCityMove()
 				{
 					iCityCaptureCount++;
 
-					if( iCityCaptureCount > 2 || 3*iCityCaptureCount > getGroup()->getNumUnits() )
+					if( iCityCaptureCount > (GC.getGameINLINE().isOption(GAMEOPTION_NON_LETHAL_COMBAT) ? 2 : 5) || 3*iCityCaptureCount > getGroup()->getNumUnits() )
 					{
 						bReadyToAttack = true;
 					}

--- a/mod-components/Assets/XML/Buildings/CIV4BuildingInfos.xml
+++ b/mod-components/Assets/XML/Buildings/CIV4BuildingInfos.xml
@@ -21710,7 +21710,7 @@
 			<SeaPlotYieldChanges>
 				<iYield>0</iYield>
 				<iYield>0</iYield>
-				<iYield>1</iYield>
+				<iYield>2</iYield>
 			</SeaPlotYieldChanges>
 			<RiverPlotYieldChanges/>
 			<GlobalSeaPlotYieldChanges/>

--- a/mod-components/Assets/XML/GameInfo/CIV4CivicInfos.xml
+++ b/mod-components/Assets/XML/GameInfo/CIV4CivicInfos.xml
@@ -1158,7 +1158,7 @@
 			<iDomesticGreatGeneralRateModifier>0</iDomesticGreatGeneralRateModifier>
 			<iStateReligionGreatPeopleRateModifier>0</iStateReligionGreatPeopleRateModifier>
 			<iDistanceMaintenanceModifier>0</iDistanceMaintenanceModifier>
-			<iNumCitiesMaintenanceModifier>0</iNumCitiesMaintenanceModifier>
+			<iNumCitiesMaintenanceModifier>-25</iNumCitiesMaintenanceModifier>
 			<iCorporationMaintenanceModifier>0</iCorporationMaintenanceModifier>
 			<iExtraHealth>0</iExtraHealth>
 			<iFreeExperience>0</iFreeExperience>
@@ -1204,7 +1204,16 @@
 			<BuildingHappinessChanges/>
 			<BuildingHealthChanges/>
 			<FeatureHappinessChanges/>
-			<ImprovementYieldChanges/>
+			<ImprovementYieldChanges>
+				<ImprovementYieldChange>
+					<ImprovementType>IMPROVEMENT_WORKSHOP</ImprovementType>
+					<ImprovementYields>
+						<iYield>0</iYield>
+						<iYield>0</iYield>
+						<iYield>1</iYield>
+					</ImprovementYields>
+				</ImprovementYieldChange>
+			</ImprovementYieldChanges>
 			<WeLoveTheKing/>
 		</CivicInfo>
 		<CivicInfo>

--- a/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
+++ b/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
@@ -8,11 +8,11 @@
 <Civ4GameText xmlns="http://www.firaxis.com">
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION</Tag>
-		<English>Civilization 4-Ever v3.7.3</English>
+		<English>Civilization 4-Ever v3.8.0</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION_SAVE</Tag>
-		<English>4-Ever v3.7.3</English>
+		<English>4-Ever v3.8.0</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_HURRY_EMBARGO</Tag>


### PR DESCRIPTION
 - AI is willing to attack cities with fewer units if non-lethal combat is on (less chance of failed siege in one turn)
 - AI keeps more gold on hand during a war
 - AI wont sacrifice research for money when able to hurry production now
 - AI will attempt to stockpile money if losing a war, hopefully it rushes production with it
 - restored some BBAI commerce slider math that was broken because of the one percent increments
 - colossus buffed to +2 per sea plot in city
 - mercantilism now also gives -25% maintenance from number of cities and workshops +1 commerce
 - bumped version to 3.8.0 