### PR TITLE
Wonder rebalance

### DIFF
--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -4778,6 +4778,7 @@ int CvCity::hurryPopulation(HurryTypes eHurry) const
 int CvCity::getModifiedProductionPerPopulation(HurryTypes eHurry) const
 {
 	int iProductionPerPopulation = GC.getGameINLINE().getProductionPerPopulation(eHurry);
+	iProductionPerPopulation += (GC.getDefineINT("POPULATION_HURRY_ERA_BONUS") * GET_PLAYER(getOwner()).getCurrentEra() * 100) / std::max(1, GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getHurryPercent());
 	BuildingTypes eCurBuilding = getProductionBuilding();
 	if (eCurBuilding != NO_BUILDING)
 	{

--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -4781,13 +4781,19 @@ int CvCity::getModifiedProductionPerPopulation(HurryTypes eHurry) const
 	BuildingTypes eCurBuilding = getProductionBuilding();
 	if (eCurBuilding != NO_BUILDING)
 	{
-		CvBuildingClassInfo cTemp = GC.getBuildingClassInfo((BuildingClassTypes)GC.getBuildingInfo(eCurBuilding).getBuildingClassType());
-		if (cTemp.getMaxGlobalInstances() != -1 || cTemp.getMaxPlayerInstances() != -1 || cTemp.getMaxTeamInstances() != -1) // is wonder
-		{
-			int iNumerator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_NUMERATOR");
-			int iDenominator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_DENOMINATOR");
-			iProductionPerPopulation *= iNumerator;
-			iProductionPerPopulation /= iDenominator;
+		FAssertMsg(eCurBuilding < GC.getNumBuildingInfos() && eCurBuilding > -1, "building is not a building");
+		if (eCurBuilding < GC.getNumBuildingInfos() && eCurBuilding > -1) {
+			BuildingClassTypes eTempBuildingClass = (BuildingClassTypes)(GC.getBuildingInfo(eCurBuilding).getBuildingClassType());
+			FAssertMsg(eTempBuildingClass < GC.getNumBuildingClassInfos() && eTempBuildingClass > 0, "building has invalid building class info");
+			if (eTempBuildingClass < GC.getNumBuildingClassInfos() && eTempBuildingClass > 0) {
+				if (isWorldWonderClass(eTempBuildingClass) || isNationalWonderClass(eTempBuildingClass) || isTeamWonderClass(eTempBuildingClass)) // is wonder
+				{
+					int iNumerator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_NUMERATOR");
+					int iDenominator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_DENOMINATOR");
+					iProductionPerPopulation *= iNumerator;
+					iProductionPerPopulation /= iDenominator;
+				}
+			}
 		}
 	}
 	return iProductionPerPopulation;

--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -4728,6 +4728,7 @@ int CvCity::getHurryCost(bool bExtra, BuildingTypes eBuilding, bool bIgnoreNew) 
 }
 
 //@HURRY
+// Cost in hammers to finish production
 int CvCity::getHurryCost(bool bExtra, int iProductionLeft, int iHurryModifier, int iModifier) const
 {
 	//remaining production to be paid for
@@ -4774,6 +4775,24 @@ int CvCity::hurryPopulation(HurryTypes eHurry) const
 	return (getHurryPopulation(eHurry, hurryCost(true)));
 }
 
+int CvCity::getModifiedProductionPerPopulation(HurryTypes eHurry) const
+{
+	int iProductionPerPopulation = GC.getGameINLINE().getProductionPerPopulation(eHurry);
+	BuildingTypes eCurBuilding = getProductionBuilding();
+	if (eCurBuilding != NO_BUILDING)
+	{
+		CvBuildingClassInfo cTemp = GC.getBuildingClassInfo((BuildingClassTypes)GC.getBuildingInfo(eCurBuilding).getBuildingClassType());
+		if (cTemp.getMaxGlobalInstances() != -1 || cTemp.getMaxPlayerInstances() != -1 || cTemp.getMaxTeamInstances() != -1) // is wonder
+		{
+			int iNumerator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_NUMERATOR");
+			int iDenominator = GC.getDefineINT("POPULATION_HURRY_WONDER_MODIFIER_DENOMINATOR");
+			iProductionPerPopulation *= iNumerator;
+			iProductionPerPopulation /= iDenominator;
+		}
+	}
+	return iProductionPerPopulation;
+}
+
 //@HURRY
 // hurry cost already accounts for the modifier of the object being hurried
 int CvCity::getHurryPopulation(HurryTypes eHurry, int iHurryCost) const
@@ -4783,7 +4802,7 @@ int CvCity::getHurryPopulation(HurryTypes eHurry, int iHurryCost) const
 		return 0;
 	}
 
-	int iPopulation = (iHurryCost - 1) / GC.getGameINLINE().getProductionPerPopulation(eHurry);
+	int iPopulation = (iHurryCost - 1) / getModifiedProductionPerPopulation(eHurry);
 	
 	iPopulation += 1;
 
@@ -4822,7 +4841,7 @@ int CvCity::hurryProduction(HurryTypes eHurry) const
 				iTemp *= 2;
 			}
 		}*/
-		iProduction = (100 * getExtraProductionDifference(hurryPopulation(eHurry) * GC.getGameINLINE().getProductionPerPopulation(eHurry))) / std::max(1, getHurryCostModifier());
+		iProduction = (100 * getExtraProductionDifference(hurryPopulation(eHurry) * getModifiedProductionPerPopulation(eHurry))) / std::max(1, getHurryCostModifier());
 		//iProduction = (100 * getExtraProductionDifference(iTemp * GC.getGameINLINE().getProductionPerPopulation(eHurry))) / std::max(1, getHurryCostModifier());
 		//END FIX
 		

--- a/CvGameCoreDLL/CvCity.h
+++ b/CvGameCoreDLL/CvCity.h
@@ -1225,6 +1225,7 @@ protected:
 	int getHurryCost(bool bExtra, UnitTypes eUnit, bool bIgnoreNew) const;
 	int getHurryCost(bool bExtra, BuildingTypes eBuilding, bool bIgnoreNew) const;
 	int getHurryCost(bool bExtra, int iProductionLeft, int iHurryModifier, int iModifier) const;
+	int getModifiedProductionPerPopulation(HurryTypes eHurry) const;
 	int getHurryPopulation(HurryTypes eHurry, int iHurryCost) const;
 	int getHurryGold(HurryTypes eHurry, int iHurryCost) const;
 	bool canHurryUnit(HurryTypes eHurry, UnitTypes eUnit, bool bIgnoreNew) const;

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -22877,7 +22877,7 @@ int CvUnitAI::AI_pillageValue(CvPlot* pPlot, int iBonusValueThreshold)
 
 		if (getDomainType() != DOMAIN_AIR)
 		{
-			iValue += GC.getImprovementInfo(eImprovement).getPillageGold() * (GET_PLAYER(pPlot->getOwner()).getCurrentEra()+1);
+			iValue += GC.getImprovementInfo(eImprovement).getPillageGold() * (GET_PLAYER(pPlot->getOwner()).getCurrentEra() + 1);
 		}
 
 		if (eNonObsoleteBonus != NO_BONUS)

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -22877,7 +22877,7 @@ int CvUnitAI::AI_pillageValue(CvPlot* pPlot, int iBonusValueThreshold)
 
 		if (getDomainType() != DOMAIN_AIR)
 		{
-			iValue += GC.getImprovementInfo(eImprovement).getPillageGold();
+			iValue += GC.getImprovementInfo(eImprovement).getPillageGold() * (GET_PLAYER(pPlot->getOwner()).getCurrentEra()+1);
 		}
 
 		if (eNonObsoleteBonus != NO_BONUS)

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -22877,7 +22877,8 @@ int CvUnitAI::AI_pillageValue(CvPlot* pPlot, int iBonusValueThreshold)
 
 		if (getDomainType() != DOMAIN_AIR)
 		{
-			iValue += GC.getImprovementInfo(eImprovement).getPillageGold() * (GET_PLAYER(pPlot->getOwner()).getCurrentEra() + 1);
+			iValue += GC.getImprovementInfo(eImprovement).getPillageGold();
+			
 		}
 
 		if (eNonObsoleteBonus != NO_BONUS)

--- a/CvGameCoreDLL/CvUnitAI.cpp
+++ b/CvGameCoreDLL/CvUnitAI.cpp
@@ -22878,7 +22878,6 @@ int CvUnitAI::AI_pillageValue(CvPlot* pPlot, int iBonusValueThreshold)
 		if (getDomainType() != DOMAIN_AIR)
 		{
 			iValue += GC.getImprovementInfo(eImprovement).getPillageGold();
-			
 		}
 
 		if (eNonObsoleteBonus != NO_BONUS)

--- a/mod-components/Assets/XML/Buildings/CIV4BuildingInfos.xml
+++ b/mod-components/Assets/XML/Buildings/CIV4BuildingInfos.xml
@@ -19523,7 +19523,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>400</iCost>
+			<iCost>600</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -20940,7 +20940,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>120</iCost>
+			<iCost>150</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -21477,7 +21477,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>300</iCost>
+			<iCost>400</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -21657,7 +21657,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>250</iCost>
+			<iCost>300</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -22018,7 +22018,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>400</iCost>
+			<iCost>450</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -23087,7 +23087,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>550</iCost>
+			<iCost>650</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -23437,7 +23437,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>800</iCost>
+			<iCost>1100</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -23977,7 +23977,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>800</iCost>
+			<iCost>1000</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -24147,7 +24147,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>800</iCost>
+			<iCost>1000</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -25329,7 +25329,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>350</iCost>
+			<iCost>180</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -25687,7 +25687,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>150</iCost>
+			<iCost>200</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -25862,7 +25862,7 @@
 			<bPrereqReligion>0</bPrereqReligion>
 			<bCenterInCity>0</bCenterInCity>
 			<iAIWeight>0</iAIWeight>
-			<iCost>300</iCost>
+			<iCost>350</iCost>
 			<iHurryCostModifier>200</iHurryCostModifier>
 			<iAdvancedStartCost>-1</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>

--- a/mod-components/Assets/XML/GlobalDefines.xml
+++ b/mod-components/Assets/XML/GlobalDefines.xml
@@ -354,6 +354,14 @@
 		<iDefineIntVal>50</iDefineIntVal> <!-- @HURRY -->
 	</Define>
 	<Define>
+		<DefineName>POPULATION_HURRY_WONDER_MODIFIER_NUMERATOR</DefineName>
+		<iDefineIntVal>3</iDefineIntVal> <!-- @HURRY -->
+	</Define>
+	<Define>
+		<DefineName>POPULATION_HURRY_WONDER_MODIFIER_DENOMINATOR</DefineName>
+		<iDefineIntVal>2</iDefineIntVal> <!-- @HURRY -->
+	</Define>
+	<Define>
 		<DefineName>CONSCRIPT_MIN_CITY_POPULATION</DefineName>
 		<iDefineIntVal>5</iDefineIntVal>
 	</Define>

--- a/mod-components/Assets/XML/GlobalDefines.xml
+++ b/mod-components/Assets/XML/GlobalDefines.xml
@@ -362,6 +362,10 @@
 		<iDefineIntVal>2</iDefineIntVal> <!-- @HURRY -->
 	</Define>
 	<Define>
+		<DefineName>POPULATION_HURRY_ERA_BONUS</DefineName>
+		<iDefineIntVal>4</iDefineIntVal> <!-- @HURRY -->
+	</Define>
+	<Define>
 		<DefineName>CONSCRIPT_MIN_CITY_POPULATION</DefineName>
 		<iDefineIntVal>5</iDefineIntVal>
 	</Define>

--- a/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
+++ b/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
@@ -8,11 +8,11 @@
 <Civ4GameText xmlns="http://www.firaxis.com">
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION</Tag>
-		<English>Civilization 4-Ever v4.1.0-rc2</English>
+		<English>Civilization 4-Ever v4.1.0</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION_SAVE</Tag>
-		<English>4-Ever v4.1.0-rc2</English>
+		<English>4-Ever v4.1.0</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_HURRY_EMBARGO</Tag>

--- a/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
+++ b/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
@@ -8,11 +8,11 @@
 <Civ4GameText xmlns="http://www.firaxis.com">
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION</Tag>
-		<English>Civilization 4-Ever v4.0.1</English>
+		<English>Civilization 4-Ever v4.1.0-rc1</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION_SAVE</Tag>
-		<English>4-Ever v4.0.1</English>
+		<English>4-Ever v4.1.0-rc1</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_HURRY_EMBARGO</Tag>

--- a/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
+++ b/mod-components/Assets/XML/Text/Civ4GameText_Forever.xml
@@ -8,11 +8,11 @@
 <Civ4GameText xmlns="http://www.firaxis.com">
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION</Tag>
-		<English>Civilization 4-Ever v4.1.0-rc1</English>
+		<English>Civilization 4-Ever v4.1.0-rc2</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_FOREVER_VERSION_SAVE</Tag>
-		<English>4-Ever v4.1.0-rc1</English>
+		<English>4-Ever v4.1.0-rc2</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_HURRY_EMBARGO</Tag>


### PR DESCRIPTION
- slavery hammers per pop bonus to wonders is back and not crashing
- adjusted several wonder costs
   - Stonehenge +25%
   - Temple of Artemis -48%
   - Great Wall +33%
   - Colossus +20%
   - Hanging Gardens +33%
   - Parthenon +12.5%
   - Statue of Zeus +16%
   - Notre Dame +18%
   - Oxford +50%
   - Kremlin +38%
   - Broadway +38%
   - Rock'n'Roll +38%
- slaves make more hammers per era now to offset the era tax